### PR TITLE
ci: delivery workflow — CI on PRs + gated, tagged publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      - run: npm test
+      - run: npm run build

--- a/justfile
+++ b/justfile
@@ -37,11 +37,17 @@ publish bump_type="patch":
     new_version="$major.$minor.$patch"
     echo "New version: $new_version"
     
+    # Gate on a clean install + tests + build before touching the registry
+    npm ci
+    npm test
+    npm run build
+
     # Update package.json
     node -e "const fs=require('fs'); const pkg=JSON.parse(fs.readFileSync('package.json','utf8')); pkg.version='$new_version'; fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');"
-    
-    # Commit, publish, and push
+
+    # Commit, tag, publish, and push (tag correlates the git ref to the published version)
     git add package.json
     git commit -m "Bump version to $new_version"
+    git tag "v$new_version"
     npm publish --access public
-    git push
+    git push --follow-tags


### PR DESCRIPTION
Stands up a delivery workflow for the library so subsequent hardening PRs are gated.

## What
- **`.github/workflows/ci.yml`** — runs `npm ci` + `npm test` + `npm run build` on every pull request and push to `master` (Node 24).
- **`justfile` publish recipe** — now runs a clean install + tests + build *before* publishing, and tags each release `v<version>` so the git ref maps to the npm version.

## Why
The repo had no CI, so nothing gated changes to a library that underpins the consuming app's money math and IDs. This is the enabler for the value-objects hardening epic; it also lands the CI half of the release-hygiene card.

## Test
- `npm test` → 22 passing locally; `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)