### PR TITLE
fix: numeric-VO non-finite guards + phantom nanoid dep + unwrap() helper

### DIFF
--- a/__tests__/NumberValueObject.spec.ts
+++ b/__tests__/NumberValueObject.spec.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { NumberValueObject } from "../src/NumberValueObject";
+import { PriceValueObject } from "../src/PriceValueObject";
+
+describe("NumberValueObject non-finite guards", () => {
+  it("rejects NaN at construction", () => {
+    expect(() => new NumberValueObject(NaN)).toThrow();
+  });
+
+  it("rejects Infinity at construction", () => {
+    expect(() => new NumberValueObject(Infinity)).toThrow();
+    expect(() => new NumberValueObject(-Infinity)).toThrow();
+  });
+
+  it("still accepts ordinary finite numbers", () => {
+    expect(new NumberValueObject(0).value).toBe(0);
+    expect(new NumberValueObject(-12.34).value).toBe(-12.34);
+  });
+
+  it("throws on divide by zero instead of yielding Infinity", () => {
+    const ten = new NumberValueObject(10);
+    expect(() => ten.divide(NumberValueObject.zero())).toThrow();
+  });
+
+  it("throws on 0 / 0 instead of yielding NaN", () => {
+    expect(() =>
+      NumberValueObject.zero().divide(NumberValueObject.zero())
+    ).toThrow();
+  });
+
+  it("propagates the guard through a non-finite arithmetic result", () => {
+    const big = new NumberValueObject(Number.MAX_VALUE);
+    expect(() => big.times(new NumberValueObject(Number.MAX_VALUE))).toThrow();
+  });
+});
+
+describe("PriceValueObject non-finite guards", () => {
+  it("throws on divide by zero", () => {
+    const price = new PriceValueObject(100, { decimals: 2 });
+    expect(() => price.divide(PriceValueObject.zero())).toThrow();
+  });
+
+  it("rejects a non-finite construction", () => {
+    expect(() => new PriceValueObject(Infinity)).toThrow();
+  });
+});

--- a/__tests__/unwrap.spec.ts
+++ b/__tests__/unwrap.spec.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { unwrap } from "../src/unwrap";
+import { StringValueObject } from "../src/StringValueObject";
+import { NumberValueObject } from "../src/NumberValueObject";
+import { PriceValueObject } from "../src/PriceValueObject";
+
+describe("unwrap", () => {
+  it("returns a primitive unchanged", () => {
+    expect(unwrap("hello")).toBe("hello");
+    expect(unwrap(42)).toBe(42);
+    expect(unwrap(null)).toBe(null);
+    expect(unwrap(undefined)).toBe(undefined);
+  });
+
+  it("reads .value off a value object", () => {
+    expect(unwrap(new StringValueObject("abc"))).toBe("abc");
+    expect(unwrap(new NumberValueObject(7))).toBe(7);
+    expect(unwrap(new PriceValueObject(5, { decimals: 2 }))).toBe(5);
+  });
+
+  it("recursively unwraps nested value objects", () => {
+    const nested = { value: new StringValueObject("deep") };
+    expect(unwrap(nested)).toBe("deep");
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "bcrypt": "^6.0.0",
+        "nanoid": "^3.3.8",
         "tslib": "^2.8.1",
         "uuid": "^14.0.0"
       },
@@ -1404,7 +1405,6 @@
       "version": "3.3.12",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
       "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "bcrypt": "^6.0.0",
+    "nanoid": "^3.3.8",
     "tslib": "^2.8.1",
     "uuid": "^14.0.0"
   },

--- a/src/NumberValueObject.ts
+++ b/src/NumberValueObject.ts
@@ -4,10 +4,12 @@ import { IValueObject } from "./IValueObject";
 export class NumberValueObject extends Number implements IValueObject<number> {
   constructor(readonly value: number) {
     super(value);
+    if (!Number.isFinite(value))
+      throw new InvalidArgumentError("NumberValueObject", value);
   }
 
   validate(): Error | void {
-    if (typeof this.value !== "number")
+    if (typeof this.value !== "number" || !Number.isFinite(this.value))
       return new InvalidArgumentError("NumberValueObject", this.value);
   }
 
@@ -32,6 +34,8 @@ export class NumberValueObject extends Number implements IValueObject<number> {
   }
 
   divide(o: IValueObject<number>): NumberValueObject {
+    if (o.value === 0)
+      throw new InvalidArgumentError("NumberValueObject.divide", o.value);
     return new NumberValueObject(this.value / o.value);
   }
 

--- a/src/PriceValueObject.ts
+++ b/src/PriceValueObject.ts
@@ -1,5 +1,6 @@
 import { IValueObject } from "./IValueObject";
 import { NumberValueObject } from "./NumberValueObject";
+import { InvalidArgumentError } from "./errors";
 
 export type PriceValueObjectConfig = {
   withSign?: boolean;
@@ -36,6 +37,8 @@ export class PriceValueObject extends NumberValueObject {
   }
 
   divide(o: IValueObject<number>): PriceValueObject {
+    if (o.value === 0)
+      throw new InvalidArgumentError("PriceValueObject.divide", o.value);
     return new PriceValueObject(this.value / o.value, this._config);
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,3 +16,4 @@ export * from './PriceValueObject';
 export * from './RecordValueObject';
 export * from './StringValueObject';
 export * from './UUIDValueObject';
+export * from './unwrap';

--- a/src/unwrap.ts
+++ b/src/unwrap.ts
@@ -1,0 +1,11 @@
+type Primitive = string | number | boolean | bigint | null | undefined;
+
+function hasValueProperty(value: object): value is { value: unknown } {
+  return "value" in value;
+}
+
+export function unwrap(value: unknown): Primitive {
+  if (typeof value === "object" && value !== null && hasValueProperty(value))
+    return unwrap(value.value);
+  return value as Primitive;
+}


### PR DESCRIPTION
Bundles three low-risk, high-confidence hardening cards from the value-objects hardening epic.

## Changes
1. **Non-finite / divide-by-zero guards** — `NumberValueObject`/`PriceValueObject` now reject `NaN`/`Infinity` at construction and throw `InvalidArgumentError` on divide-by-zero, instead of silently emitting `Infinity`/`NaN`. The constructor guard covers *every* arithmetic path; `divide` adds an explicit clearer error. (Consuming app hit this via a monthly-estimate path that divided by a possibly-zero frequency.)
2. **Declare the phantom `nanoid` dependency** (`^3.3.8`, CJS-safe) — `NanoIDValueObject` imports `nanoid` but it was undeclared, resolving only by accidental hoist; strict/isolated installs (pnpm/PnP) would break ID generation.
3. **Official `unwrap()` helper** — recursively reads `.value`, so consumers stop duplicating an unwrap for the `String`/`Number`-extending VOs.

## ⚠️ Behavior change
Constructing a numeric VO from `NaN`/`Infinity` or dividing by zero now **throws** where it previously succeeded silently → at least a **minor** bump (arguably major). Called out for the version decision at publish.

## Test
- `npm test` → **33 passing** (22 pre-existing + 11 new for guards/unwrap); `npm run build` clean; clean `npm install` verified.
- CI (from PR #7) attaches once that PR merges and this rebases; verified green locally in the meantime.

Cards: RVaL0rRazEP5 (guards), A0P2m3y5jWXn (nanoid), wL0MGEq0Uv8Z (unwrap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)