### PR TITLE
feat: deterministic decimal rounding for money-safe PriceValueObject (C2)

### DIFF
--- a/__tests__/PriceValueObject.rounding.spec.ts
+++ b/__tests__/PriceValueObject.rounding.spec.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { PriceValueObject } from "../src/PriceValueObject";
+
+const cents = (n: number) => new PriceValueObject(n, { decimals: 2 });
+
+describe("PriceValueObject deterministic rounding (decimals >= 0)", () => {
+  it("rounds float noise to the configured decimals on construction", () => {
+    expect(cents(0.1 + 0.2).value).toBe(0.3);
+    expect(cents(1.234).value).toBe(1.23);
+    expect(cents(1.235).value).toBe(1.24);
+  });
+
+  it("makes money equality exact after arithmetic (no epsilon needed)", () => {
+    const sum = cents(0.1).plus(cents(0.2));
+    expect(sum.value).toBe(0.3);
+    expect(sum.equalTo(cents(0.3))).toBe(true);
+  });
+
+  it("keeps chained arithmetic reconciled to cents (no accumulation drift)", () => {
+    let total = cents(0);
+    for (let i = 0; i < 10; i++) total = total.plus(cents(0.1));
+    expect(total.value).toBe(1);
+  });
+
+  it("re-rounds through times/divide", () => {
+    expect(cents(10).divide(cents(3)).value).toBe(3.33);
+    expect(cents(0.1).times(cents(3)).value).toBe(0.3);
+  });
+
+  it("fixed() rounds correctly instead of via toFixed float artifacts", () => {
+    expect(cents(1.239).fixed(2).value).toBe(1.24);
+  });
+
+  it("propagates the left operand's config through arithmetic", () => {
+    const unrounded = PriceValueObject.zero().plus(cents(0.1).plus(cents(0.2)));
+    expect(unrounded.value).toBe(0.3);
+    const seeded = cents(0).plus(cents(0.1)).plus(cents(0.2));
+    expect(seeded.value).toBe(0.3);
+  });
+
+  it("does NOT round when decimals is unset or negative (unlimited precision preserved)", () => {
+    expect(new PriceValueObject(1234.0123456789, { decimals: -1 }).value).toBe(
+      1234.0123456789
+    );
+    expect(new PriceValueObject(1.2345, { withSign: true }).value).toBe(1.2345);
+  });
+});

--- a/src/PriceValueObject.ts
+++ b/src/PriceValueObject.ts
@@ -2,6 +2,15 @@ import { IValueObject } from "./IValueObject";
 import { NumberValueObject } from "./NumberValueObject";
 import { InvalidArgumentError } from "./errors";
 
+export const PRICE_DECIMAL_BASE = 10;
+
+export function roundToDecimals(value: number, decimals: number): number {
+  const factor = PRICE_DECIMAL_BASE ** decimals;
+  const rounded =
+    (Math.sign(value) * Math.round(Math.abs(value) * factor)) / factor;
+  return rounded === 0 ? 0 : rounded;
+}
+
 export type PriceValueObjectConfig = {
   withSign?: boolean;
   withZeros?: boolean;
@@ -13,11 +22,20 @@ export const PriceValueObjectDefaultConfig: PriceValueObjectConfig = {
 };
 
 export class PriceValueObject extends NumberValueObject {
+  readonly price: number;
+  private readonly _config: PriceValueObjectConfig;
+
   constructor(
-    readonly price: number,
-    private readonly _config: PriceValueObjectConfig = PriceValueObjectDefaultConfig
+    price: number,
+    config: PriceValueObjectConfig = PriceValueObjectDefaultConfig
   ) {
-    super(price);
+    const rounded =
+      config.decimals != null && config.decimals >= 0
+        ? roundToDecimals(price, config.decimals)
+        : price;
+    super(rounded);
+    this.price = rounded;
+    this._config = config;
   }
 
   static zero(): PriceValueObject {
@@ -51,10 +69,7 @@ export class PriceValueObject extends NumberValueObject {
   }
 
   fixed(n: number): PriceValueObject {
-    return new PriceValueObject(
-      parseFloat(this.value.toFixed(n)),
-      this._config
-    );
+    return new PriceValueObject(roundToDecimals(this.value, n), this._config);
   }
 
   toString(): string {


### PR DESCRIPTION
Reopened against `master` (original #9 was auto-closed when #8's branch — its stacked base — was deleted on merge). Same change, now cleanly rebased onto master.

## What
- `PriceValueObject` with `decimals >= 0` now **rounds on construction** (scaled `Math.round`) and in `fixed()`, so `plus/subtract/times/divide` stay cents-reconciled instead of accumulating float drift.
- Money **equality becomes exact** — `0.1 + 0.2` rounds to `0.3`, so `equalTo` is correct **without** a blanket epsilon.

## Preserves existing behavior
Rounding is **opt-in** via `decimals >= 0`; default and unlimited-precision paths are byte-identical — **all 22 pre-existing formatting tests pass unchanged**.

## Honest limits
Arithmetic inherits the **left operand's** config (documented + tested). `.xx5` boundaries not float-representable (e.g. `1.005`) still round per IEEE-754 — true half-up needs integer-cents (noted follow-up).

## Test
`npm test` → **40 passing**; `npm run build` clean. CI will run now that #7 is on master.

Card: ccA0dPiQ7nMA. ⚠️ Behavior change → part of the 3.0.0 major.

🤖 Generated with [Claude Code](https://claude.com/claude-code)