### PR TITLE
chore: add engines, keywords, author package metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,9 +12,20 @@
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "keywords": [],
-  "author": "",
+  "keywords": [
+    "ddd",
+    "domain-driven-design",
+    "value-objects",
+    "value-object",
+    "typescript",
+    "money",
+    "price"
+  ],
+  "author": "Juan Diego Ardila",
   "license": "ISC",
+  "engines": {
+    "node": ">=20"
+  },
   "repository": {
     "url": "git+https://github.com/JuanDArdilaG/value-objects.git",
     "type": "git"


### PR DESCRIPTION
Closes the metadata residue of the release-hygiene work (app-board card P4KArQKuuK8W).

## What
- `engines`: `node >=20`
- `keywords`: ddd, domain-driven-design, value-objects, value-object, typescript, money, price
- `author`: Juan Diego Ardila

No code or API change — metadata only. `npm test` (40) + `npm run build` still green; CI runs on this PR.

**Publish:** a metadata-only patch — publish as **3.0.1** via `just pub patch` after merge (needs your npm OTP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)